### PR TITLE
fix: don't call gps command when sleeping

### DIFF
--- a/custom_components/robonect/client/const.py
+++ b/custom_components/robonect/client/const.py
@@ -27,8 +27,6 @@ SAFE_COMMANDS = [
     "door",  # ok when sleeping
     "ext",  # ok when sleeping
     "health",  # ok when sleeping
-    "portal",  # ok when sleeping
-    "push",  # ok when sleeping
     "status",  # ok when sleeping
     "timer",  # ok when sleeping
     "weather",  # ok when sleeping

--- a/custom_components/robonect/client/const.py
+++ b/custom_components/robonect/client/const.py
@@ -26,7 +26,6 @@ SAFE_COMMANDS = [
     "clock",  # ok when sleeping
     "door",  # ok when sleeping
     "ext",  # ok when sleeping
-    "gps",  # ok when sleeping
     "health",  # ok when sleeping
     "portal",  # ok when sleeping
     "push",  # ok when sleeping


### PR DESCRIPTION
references #218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the list of safe commands for the Robonect client, enhancing security by limiting the commands available during sleep mode. 

- **Bug Fixes**
	- Removed potentially unsafe commands from the `SAFE_COMMANDS` list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->