### PR TITLE
fix: don't close the Home Assistant httpx client, refs #274

### DIFF
--- a/custom_components/robonect/client/client.py
+++ b/custom_components/robonect/client/client.py
@@ -79,6 +79,8 @@ class RobonectClient:
         """Properly close and cleanup the httpx client."""
         if self.client:
             # await self.client.aclose() commented as this closes the HA httpx client
+            # Don't close the client as it's a shared Home Assistant HTTPX client
+            # that's managed by Home Assistant itself
             self.client = None
 
     async def async_cmd(self, command=None, params={}) -> list[dict]:

--- a/custom_components/robonect/client/client.py
+++ b/custom_components/robonect/client/client.py
@@ -78,7 +78,7 @@ class RobonectClient:
     async def client_close(self):
         """Properly close and cleanup the httpx client."""
         if self.client:
-            await self.client.aclose()
+            # await self.client.aclose() commented as this closes the HA httpx client
             self.client = None
 
     async def async_cmd(self, command=None, params={}) -> list[dict]:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unintended closure of the shared HTTP client to ensure stable integration with Home Assistant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->