### PR TITLE
fix: parse_duration_seconds_to_minutes retaining only the digits refs #299

### DIFF
--- a/custom_components/robonect/lawn_mower.py
+++ b/custom_components/robonect/lawn_mower.py
@@ -30,7 +30,12 @@ from .const import (
     STATUS_MAPPING_LAWN_MOWER,
 )
 from .entity import RobonectCoordinatorEntity, RobonectEntity
-from .utils import filter_out_units, get_json_dict_path, unix_to_datetime
+from .utils import (
+    filter_out_units,
+    get_json_dict_path,
+    parse_duration_seconds_to_minutes,
+    unix_to_datetime,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -198,7 +203,7 @@ class RobonectLawnMowerEntity(RobonectEntity, LawnMowerEntity, RestoreEntity):
                     if key == "timer_next_unix":
                         state = unix_to_datetime(state, self.coordinator.hass)
                     elif key == "status_duration":
-                        state = f"{round(state / 60)} min"
+                        state = parse_duration_seconds_to_minutes(state)
                     elif key == "statistic_hours":
                         state = f"{state} h"
                     elif key == "distance":
@@ -258,7 +263,7 @@ class RobonectLawnMowerEntity(RobonectEntity, LawnMowerEntity, RestoreEntity):
                     slug = "status_mode"
                     payload = f"s_{payload}"
                 elif slug == "status_duration":
-                    payload = f"{round(payload / 60)} min"
+                    payload = parse_duration_seconds_to_minutes(payload)
                 elif slug == "statistic_hours":
                     payload = f"{payload} h"
                 elif slug == "distance":

--- a/custom_components/robonect/translations/fr.json
+++ b/custom_components/robonect/translations/fr.json
@@ -209,7 +209,7 @@
             "state": {
               "s_0": "Automatique",
               "s_1": "Manuel",
-              "s_2": "Accueil",
+              "s_2": "Garage",
               "s_3": "D\u00e9mo",
               "s_98": "Fin de journ\u00e9e",
               "s_99": "Mission de tonte"

--- a/custom_components/robonect/utils.py
+++ b/custom_components/robonect/utils.py
@@ -17,6 +17,18 @@ _LOGGER = logging.getLogger(__name__)
 _cached_timezone = None
 
 
+def parse_duration_seconds_to_minutes(payload: str) -> str:
+    """Parse a duration in seconds to minutes appending it with min."""
+
+    match = re.search(r"(\d+)", payload)
+    if match:
+        seconds = int(match.group(1))
+        minutes = round(seconds / 60)
+        return f"{minutes} min"
+    else:
+        return "unknown duration"
+
+
 def get_cached_timezone(hass):
     """Get the cached timezone."""
     global _cached_timezone


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved display of duration values by converting seconds to a more readable minutes format.
- **Localization**
	- Updated the French translation for mower mode state "s_2" from "Accueil" to "Garage".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->