### PR TITLE
fix: parse_duration_seconds_to_minutes takes both string as int as payload now

### DIFF
--- a/custom_components/robonect/utils.py
+++ b/custom_components/robonect/utils.py
@@ -17,16 +17,21 @@ _LOGGER = logging.getLogger(__name__)
 _cached_timezone = None
 
 
-def parse_duration_seconds_to_minutes(payload: str) -> str:
+def parse_duration_seconds_to_minutes(payload: str | int) -> str:
     """Parse a duration in seconds to minutes appending it with min."""
 
-    match = re.search(r"(\d+)", payload)
-    if match:
-        seconds = int(match.group(1))
-        minutes = round(seconds / 60)
-        return f"{minutes} min"
+    if isinstance(payload, int):
+        seconds = payload
     else:
-        return "unknown duration"
+        # assume string, extract number with regex
+        match = re.search(r"(\d+)", payload)
+        if match:
+            seconds = int(match.group(1))
+        else:
+            return "unknown duration"
+
+    minutes = round(seconds / 60)
+    return f"{minutes} min"
 
 
 def get_cached_timezone(hass):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved duration parsing to better handle both numeric and string inputs, ensuring more accurate conversion of seconds to minutes and clearer messaging for unknown durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->