### PR TITLE
fix: ensure category data is a dictionary before accessing attributes

### DIFF
--- a/custom_components/robonect/sensor.py
+++ b/custom_components/robonect/sensor.py
@@ -324,7 +324,11 @@ class RobonectRestSensor(RobonectCoordinatorEntity, RobonectSensor):
 
     def set_extra_attributes(self):
         """Set the attributes for the sensor from coordinator."""
-        if len(self.coordinator.data) and self.category in self.coordinator.data:
+        if (
+            len(self.coordinator.data)
+            and self.category in self.coordinator.data
+            and isinstance(self.coordinator.data[self.category], dict)
+        ):
             attributes = {
                 "last_synced": self.coordinator.data[self.category]["sync_time"],
                 "category": self.category,


### PR DESCRIPTION
Fixes #391 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sensor reliability when category data is missing or has an unexpected format.
  * Invalid category values are now safely skipped instead of causing attribute-processing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->